### PR TITLE
Fix vertical alignment uui-symbol-expand.element.ts

### DIFF
--- a/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
+++ b/packages/uui-symbol-expand/lib/uui-symbol-expand.element.ts
@@ -33,7 +33,7 @@ export class UUISymbolExpandElement extends LitElement {
   static styles = [
     css`
       :host {
-        display: inline-block;
+        display: inline-flex;
         width: 12px;
         vertical-align: middle;
       }


### PR DESCRIPTION
Changed display property from inline-block to inline-flex

## Description

Fixed vertical alignment by changing css display property from inline-block to inline-flex

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

It solves vertical alignment of carrot icon against menu item in umbraco backoffice tree menu

## How to test?
After:
![after](https://github.com/user-attachments/assets/f6f3e860-d2d9-4c5e-b905-c62a2011eed0)
Before:
![before](https://github.com/user-attachments/assets/f68c7f03-562a-438c-81c9-1f115fd4d28d)


## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.UI/blob/v1/contrib/docs/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
